### PR TITLE
PHP 7.0 compatibility

### DIFF
--- a/src/font/unifont/ttfonts.php
+++ b/src/font/unifont/ttfonts.php
@@ -69,7 +69,7 @@ var $charWidths;
 var $defaultWidth;
 var $maxStrLenRead;
 
-	function TTFontFile() {
+	function __construct() {
 		$this->maxStrLenRead = 200000;	// Maximum size of glyf table to read in as string (otherwise reads each glyph from file)
 	}
 

--- a/src/tFPDF.php
+++ b/src/tFPDF.php
@@ -76,7 +76,7 @@ var $PDFVersion;         // PDF version number
 *                               Public methods                                 *
 *                                                                              *
 *******************************************************************************/
-function tFPDF($orientation='P', $unit='mm', $size='A4')
+function __construct($orientation='P', $unit='mm', $size='A4')
 {
 	// Some checks
 	$this->_dochecks();


### PR DESCRIPTION
This changes constructor names to `__construct`. The old PHP 4 style constructors are [deprecated](http://php.net/manual/en/migration70.deprecated.php) in PHP 7.0.